### PR TITLE
fix: allow serving from subdirectory

### DIFF
--- a/sass/vendor/_fonts.scss
+++ b/sass/vendor/_fonts.scss
@@ -3,7 +3,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('../webfonts/PressStart2P-cyrillic-v15.woff2') format('woff2');
+  src: url('webfonts/PressStart2P-cyrillic-v15.woff2') format('woff2');
   unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -12,7 +12,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('../webfonts/PressStart2P-cyrillic-ext-v15.woff2') format('woff2');
+  src: url('webfonts/PressStart2P-cyrillic-ext-v15.woff2') format('woff2');
   unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -21,7 +21,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('../webfonts/PressStart2P-greek-v15.woff2') format('woff2');
+  src: url('webfonts/PressStart2P-greek-v15.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 
@@ -30,7 +30,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('../webfonts/PressStart2P-latin-ext-v15.woff2') format('woff2');
+  src: url('webfonts/PressStart2P-latin-ext-v15.woff2') format('woff2');
   unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -39,13 +39,13 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('../webfonts/PressStart2P-latin-v15.woff2') format('woff2');
+  src: url('webfonts/PressStart2P-latin-v15.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
 @font-face {
   font-family: 'Pixeboy';
-  src: url('../webfonts/Pixeboy.woff2') format('woff2');
+  src: url('webfonts/Pixeboy.woff2') format('woff2');
   font-weight: normal;
   font-style: normal;
   font-display: swap;
@@ -53,7 +53,7 @@
 
 @font-face {
   font-family: 'Hack';
-  src: url('../webfonts/hack-regular.woff2?sha=3114f1256') format('woff2');
+  src: url('webfonts/hack-regular.woff2?sha=3114f1256') format('woff2');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -61,7 +61,7 @@
 
 @font-face {
   font-family: 'Hack';
-  src: url('../webfonts/hack-bold.woff2?sha=3114f1256') format('woff2');
+  src: url('webfonts/hack-bold.woff2?sha=3114f1256') format('woff2');
   font-weight: 700;
   font-style: normal;
   font-display: swap;
@@ -69,7 +69,7 @@
 
 @font-face {
   font-family: 'Hack';
-  src: url('../webfonts/hack-italic.woff2?sha=3114f1256') format('woff2');
+  src: url('webfonts/hack-italic.woff2?sha=3114f1256') format('woff2');
   font-weight: 400;
   font-style: italic;
   font-display: swap;
@@ -77,7 +77,7 @@
 
 @font-face {
   font-family: 'Hack';
-  src: url('../webfonts/hack-bolditalic.woff2?sha=3114f1256') format('woff2');
+  src: url('webfonts/hack-bolditalic.woff2?sha=3114f1256') format('woff2');
   font-weight: 700;
   font-style: italic;
   font-display: swap;

--- a/static/search.js
+++ b/static/search.js
@@ -138,7 +138,7 @@ function initSearch() {
   
   var initIndex = async function () {
     if (index === undefined) {
-      index = fetch("/search_index.en.json")
+      index = fetch("search_index.en.json")
         .then(
           async function(response) {
             return await elasticlunr.Index.load(await response.json());

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,8 +19,8 @@
     </div>
     <div class="block-right">
       {% if config.build_search_index == true %}
-      <script type="text/javascript" src="/elasticlunr.min.js" async></script>
-      <script type="text/javascript" src="/search.js" defer></script>
+      <script type="text/javascript" src="{{ get_url(path='elasticlunr.min.js') | safe }}" async></script>
+      <script type="text/javascript" src="{{ get_url(path='search.js') | safe }}" defer></script>
       <nav class="search-container" id="search-nav">
         <input id="search" type="search" placeholder="Search" aria-label="Search">
         <div class="search-results">

--- a/templates/partials/head.html
+++ b/templates/partials/head.html
@@ -101,24 +101,24 @@
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5">
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-  <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-  <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-  <link rel="stylesheet" type="text/css" href="/unstyle.css" integrity="sha512-{{ get_hash(path="/unstyle.css", sha_type=512, base64=true) | safe }}">
-  <link rel="stylesheet" type="text/css" href="/main.css" integrity="sha512-{{ get_hash(path="/main.css", sha_type=512, base64=true) | safe }}">
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ get_url(path='apple-touch-icon.png') | safe }}">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ get_url(path='favicon-32x32.png') | safe }}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ get_url(path='favicon-16x16.png') | safe }}">
+  <link rel="stylesheet" type="text/css" href="{{ get_url(path='unstyle.css') | safe }}" integrity="sha512-{{ get_hash(path='/unstyle.css', sha_type=512, base64=true) | safe }}">
+  <link rel="stylesheet" type="text/css" href="{{ get_url(path='main.css') | safe }}" integrity="sha512-{{ get_hash(path='/main.css', sha_type=512, base64=true) | safe }}">
   {% if active_path == "/" %}
-  <link rel="stylesheet" type="text/css" href="/nerd-fonts.css" integrity="sha512-{{ get_hash(path="/nerd-fonts.css", sha_type=512, base64=true) | safe }}">
+  <link rel="stylesheet" type="text/css" href="{{ get_url(path='nerd-fonts.css') | safe }}" integrity="sha512-{{ get_hash(path='/nerd-fonts.css', sha_type=512, base64=true) | safe }}">
   {% endif %}
   {%- if config.extra.home.glitch == true %}
   {%- if current_path | default(value="none") == "/" %}
-  <link rel="stylesheet" type="text/css" href="/glitch.css" integrity="sha512-{{ get_hash(path="/glitch.css", sha_type=512, base64=true) | safe }}">
+  <link rel="stylesheet" type="text/css" href="{{ get_url(path='glitch.css') | safe }}" integrity="sha512-{{ get_hash(path='/glitch.css', sha_type=512, base64=true) | safe }}">
   {% endif %}
   {% endif %}
-  <link rel="stylesheet" type="text/css" href="/langs.css" integrity="sha512-{{ get_hash(path="/langs.css", sha_type=512, base64=true) | safe }}">
+  <link rel="stylesheet" type="text/css" href="{{ get_url(path='langs.css') | safe }}" integrity="sha512-{{ get_hash(path='/langs.css', sha_type=512, base64=true) | safe }}">
   {%- if config.markdown.highlight_code and config.markdown.highlight_theme == "css" %}
-  <link rel="stylesheet" type="text/css" href="/syntax-theme-light.css" media="(prefers-color-scheme: light)" integrity="sha512-{{ get_hash(path="/syntax-theme-light.css", sha_type=512, base64=true) | safe }}">
-  <link rel="stylesheet" type="text/css" href="/syntax-theme-dark.css" media="(prefers-color-scheme: dark)" integrity="sha512-{{ get_hash(path="/syntax-theme-dark.css", sha_type=512, base64=true) | safe }}">
-  {%- endif %}
+  <link rel="stylesheet" type="text/css" href="{{ get_url(path='syntax-theme-light.css') | safe }}" media="(prefers-color-scheme: light)" integrity="sha512-{{ get_hash(path='/syntax-theme-light.css', sha_type=512, base64=true) | safe }}">
+  <link rel="stylesheet" type="text/css" href="{{ get_url(path='syntax-theme-dark.css') | safe }}" media="(prefers-color-scheme: dark)" integrity="sha512-{{ get_hash(path='/syntax-theme-dark.css', sha_type=512, base64=true) | safe }}">
+    {%- endif %}
   {%- if config.extra.manifest %}
   {% if config.extra.menu.posts == true %}
     {% set posts = get_section(path="posts/_index.md") %}
@@ -129,7 +129,7 @@
       {% set posts_page_count = post_count / posts_config.paginate_by | round(method="ceil") | int | default(value=0) %}
     {% endif %}
   {% endif %}
-  <script defer src="/sw-load.js" integrity="sha512-{{ get_hash(path='sw-load.js', sha_type=512, base64=true) | safe }}" data-cache="{% if posts_config.paginate_by %}{% for i in range(start=2, end=posts_page_count + 1) %}{{ config.base_url ~ "/posts/page/" ~ i ~ "/" | safe }} {% endfor %}{% endif %}{% if config.taxonomies %}{% for taxonomy in config.taxonomies %}{% set inner_taxonomy = get_taxonomy(kind=taxonomy.name) %}{{ inner_taxonomy.permalink | safe }} {% for term in inner_taxonomy.items %}{{ term.permalink | safe }} {% endfor %}{% endfor %}{% endif %}{% if posts.pages %}{% for post in posts.pages %}{{ post.permalink | safe }} {% if post.assets %}{% for asset in post.assets %}{{ config.base_url ~ asset | safe }} {% endfor %}{%endif%}{% endfor %}{% endif %}{% for link in config.extra.menu.links %}{{ get_url(path=link.url, cachebust=true) | safe }} {% endfor %}{% if config.extra.menu.posts == true %} /posts/ {% endif %}{% for link in config.extra.images.categories %}{% if link.image is not matching("^http[s]?://") %}{{ link.image | safe }} {% endif %}{% endfor %}{% if config.extra.images.home is not matching("^http[s]?://") %}{{ config.extra.images.home }} {% endif %}{% if config.extra.images.post_list is not matching("^http[s]?://") %}{{ config.extra.images.post_list }} {% endif %}{% if config.extra.images.default_post is not matching("^http[s]?://") %}{{ config.extra.images.default_post }} {% endif %} {{ config.extra.logo | safe }}{% if config.extra.home.glitch %} /glitch.css{% endif %}{% if config.build_search_index == true %} /search.js /elasticlunr.min.js /search_index.{{ config.default_language }}.json{% endif %}"></script>
+  <script defer src="{{ get_url(path='sw-load.js') | safe }}" integrity="sha512-{{ get_hash(path='sw-load.js', sha_type=512, base64=true) | safe }}" data-cache="{% if posts_config.paginate_by %}{% for i in range(start=2, end=posts_page_count + 1) %}{{ config.base_url ~ "/posts/page/" ~ i ~ "/" | safe }} {% endfor %}{% endif %}{% if config.taxonomies %}{% for taxonomy in config.taxonomies %}{% set inner_taxonomy = get_taxonomy(kind=taxonomy.name) %}{{ inner_taxonomy.permalink | safe }} {% for term in inner_taxonomy.items %}{{ term.permalink | safe }} {% endfor %}{% endfor %}{% endif %}{% if posts.pages %}{% for post in posts.pages %}{{ post.permalink | safe }} {% if post.assets %}{% for asset in post.assets %}{{ config.base_url ~ asset | safe }} {% endfor %}{%endif%}{% endfor %}{% endif %}{% for link in config.extra.menu.links %}{{ get_url(path=link.url, cachebust=true) | safe }} {% endfor %}{% if config.extra.menu.posts == true %} /posts/ {% endif %}{% for link in config.extra.images.categories %}{% if link.image is not matching("^http[s]?://") %}{{ link.image | safe }} {% endif %}{% endfor %}{% if config.extra.images.home is not matching("^http[s]?://") %}{{ config.extra.images.home }} {% endif %}{% if config.extra.images.post_list is not matching("^http[s]?://") %}{{ config.extra.images.post_list }} {% endif %}{% if config.extra.images.default_post is not matching("^http[s]?://") %}{{ get_url(path=config.extra.images.default_post) }}{% endif %} {{ get_url(path=config.extra.logo) | safe }}{% if config.extra.home.glitch %}{{ get_url(path='glitch.css') }}{% endif %}{% if config.build_search_index == true %}{{ get_url(path='search.js') }} {{ get_url(path='elasticlunr.min.js') }} {{ get_url(path='search_index.' ~ lang ~ '.json') }}{% endif %}"></script>
   {%- endif %}
   {%- if page.extra.image %}
   <style>{{ macros::image_style(url=page_image) }}</style>


### PR DESCRIPTION
<!--- Thank you for contributing to Halve-Z!  -->

## Description

I was investigating #28 ([Zola discourse discussion](https://zola.discourse.group/t/i-tried-to-use-zola/2160/3)) and figured out the issue: hardcoded paths to the root of the page (`/`). The theme would work fine if someone is serving from example.com/, but not if they choose example.com/my-page/.

I changed the paths I found to use `get_url`.

Demo of current code with broken paths (see browser console): https://m0thman70.github.io/doms-websitev2.3/
Demo of new code: https://welpo.github.io/doms-websitev2.3/

## Motivation

Fixes #28.

This allows hosting a site with this theme on a subfolder (like GitHub pages forces).

## Checklist:

<!— Go over all the following points and put an `x` in all the boxes that apply. —>

- [X] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.

## Note

I noticed the search javascript is hardcoded to the `en` language index. I left it as is, but search will break if someone changes the default language.